### PR TITLE
Add Christmas Eve (Dec 24) as a public holiday in Poland

### DIFF
--- a/src/holidays.ts
+++ b/src/holidays.ts
@@ -43,6 +43,12 @@ const holidays: (FixedHoliday | MovableHoliday)[] = [
 		date: '11-11',
 		type: 'fixed',
 	},
+  {
+		name: 'Christmas Eve',
+		namePL: 'Wigilia Bożego Narodzenia',
+		date: '12-24',
+		type: 'fixed',
+  },
 	{
 		name: 'Christmas',
 		namePL: 'Boże Narodzenie',


### PR DESCRIPTION
Christmas Eve (December 24) has been officially established as a statutory public holiday in Poland starting from 2025.

Official government source:
https://www.gov.pl/web/family/free-christmas-eve-starting-from-next-year